### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,10 @@
     ],
     "require": {
     	"php": ">=5.3.2",
-    	"guzzle/guzzle": "~3.8.0"
+    	"guzzle/guzzle": "~3.8"
     },
     "require-dev": {
-    	"symfony/class-loader": "*"
+    	"symfony/class-loader": "~2.1"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Here are some composer.json improvements. Before you were being too restrictive on the guzzle version, and too open on the class-loader version. It's safe to allow newer guzzle 3.x versions as I don't think there will be any bc issues now that guzzle 4 has arrived.
