### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require-dev": {
         "symfony/class-loader": "~2.3",
-        "phpunit/phpunit": "^4.7"
+        "phpunit/phpunit": "^4.8.36"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Unit/EngineClientTest.php
+++ b/tests/Unit/EngineClientTest.php
@@ -8,9 +8,9 @@ use predictionio\EngineClient;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 
-
-class EngineClientTest extends \PHPUnit_Framework_TestCase {
+class EngineClientTest extends TestCase {
   /** @var EngineClient $engineClient */
   protected $engineClient;
   protected $container = [];
@@ -40,5 +40,3 @@ class EngineClientTest extends \PHPUnit_Framework_TestCase {
   }
 
 }
-
-?>

--- a/tests/Unit/EventClientTest.php
+++ b/tests/Unit/EventClientTest.php
@@ -8,8 +8,9 @@ use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use predictionio\EventClient;
+use PHPUnit\Framework\TestCase;
 
-class EventClientTest extends \PHPUnit_Framework_TestCase {
+class EventClientTest extends TestCase {
   /** @var  EventClient $eventClient */
   protected $eventClient;
   protected $container = [];
@@ -91,7 +92,7 @@ class EventClientTest extends \PHPUnit_Framework_TestCase {
   public function testUnsetUserWithoutProperties() {
     $this->eventClient->unsetUser(1, array());
   }
-  
+
   public function testDeleteUser() {
     $this->eventClient->deleteUser(1);
     $result=array_shift($this->container);
@@ -288,10 +289,4 @@ class EventClientTest extends \PHPUnit_Framework_TestCase {
     $this->assertEquals('http://localhost:7070/events/event_id.json?accessKey=j4jIdbq59JsF2f4CXwwkIiVHNFnyNvWXqMqXxcIbQDqFRz5K0fe9e3QfqjKwvW3O',
                 $request->getUri());
   }
-
-
-
-
 }
-?>
-

--- a/tests/Unit/ExporterTest.php
+++ b/tests/Unit/ExporterTest.php
@@ -2,8 +2,8 @@
 
 namespace predictionio\tests\Unit;
 
-
 use predictionio\Exporter;
+use PHPUnit\Framework\TestCase;
 
 class TestExporter {
     use Exporter {
@@ -28,7 +28,7 @@ class TestExporter {
     }
 }
 
-class ExporterTest extends \PHPUnit_Framework_TestCase {
+class ExporterTest extends TestCase {
 
     /** @var TestExporter $exporter */
     private $exporter;

--- a/tests/Unit/FileExporterTest.php
+++ b/tests/Unit/FileExporterTest.php
@@ -2,10 +2,10 @@
 
 namespace predictionio\tests\Unit;
 
-
 use predictionio\FileExporter;
+use PHPUnit\Framework\TestCase;
 
-class FileExporterTest extends \PHPUnit_Framework_TestCase {
+class FileExporterTest extends TestCase {
 
     public function setUp()
     {


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump `PHPUnit` version to [`4.8.36`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4836---2017-06-21), that supports this `namespace`.