### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@
 # limitations under the License.
 language: php
 php:
+  - 7.3
   - 7.2
   - 7.1
   - 7.0

--- a/composer.json
+++ b/composer.json
@@ -32,5 +32,10 @@
         "psr-4": {
             "predictionio\\": "src/predictionio/"
         }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "predictionio\\tests\\Unit\\": "tests/Unit/"
+        }
     }
 }

--- a/tests/Unit/EngineClientTest.php
+++ b/tests/Unit/EngineClientTest.php
@@ -24,8 +24,9 @@ use predictionio\EngineClient;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 
-class EngineClientTest extends \PHPUnit_Framework_TestCase
+class EngineClientTest extends TestCase
 {
     /** @var EngineClient $engineClient */
     protected $engineClient;

--- a/tests/Unit/EventClientTest.php
+++ b/tests/Unit/EventClientTest.php
@@ -24,8 +24,9 @@ use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use predictionio\EventClient;
+use PHPUnit\Framework\TestCase;
 
-class EventClientTest extends \PHPUnit_Framework_TestCase
+class EventClientTest extends TestCase
 {
     /** @var  EventClient $eventClient */
     protected $eventClient;
@@ -319,7 +320,7 @@ class EventClientTest extends \PHPUnit_Framework_TestCase
         $result=array_shift($this->container);
         /** @var Request $request */
         $request=$result['request'];
-        $body=json_decode($request->getBody(), true);
+        json_decode($request->getBody(), true);
 
         $this->assertEquals('GET', $request->getMethod());
         $this->assertEquals(

--- a/tests/Unit/ExporterTest.php
+++ b/tests/Unit/ExporterTest.php
@@ -18,6 +18,7 @@
 namespace predictionio\tests\Unit;
 
 use predictionio\Exporter;
+use PHPUnit\Framework\TestCase;
 
 class TestExporter
 {
@@ -46,7 +47,7 @@ class TestExporter
     }
 }
 
-class ExporterTest extends \PHPUnit_Framework_TestCase
+class ExporterTest extends TestCase
 {
 
     /** @var TestExporter $exporter */
@@ -63,18 +64,18 @@ class ExporterTest extends \PHPUnit_Framework_TestCase
 
         $this->exporter->createEvent('event', 'entity-type', 'entity-id');
 
-        $this->assertEquals(1, count($this->exporter->data));
+        $this->assertCount(1, $this->exporter->data);
         $data = $this->exporter->data[0];
-        $this->assertEquals(4, count($data));
+        $this->assertCount(4, $data);
         $this->assertEquals('event', $data['event']);
         $this->assertEquals('entity-type', $data['entityType']);
         $this->assertEquals('entity-id', $data['entityId']);
         $this->assertEquals($time->format(\DateTime::ISO8601), $data['eventTime'], 'time is now', 1);
 
-        $this->assertEquals(1, count($this->exporter->json));
+        $this->assertCount(1, $this->exporter->json);
         $json = $this->exporter->json[0];
         $pattern = '/^{"event":"event","entityType":"entity-type","entityId":"entity-id","eventTime":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{4}"}$/';
-        $this->assertTrue(preg_match($pattern, $json) === 1, 'json');
+        $this->assertRegExp($pattern, $json, 'json');
     }
 
     public function testTimeIsString()
@@ -83,18 +84,18 @@ class ExporterTest extends \PHPUnit_Framework_TestCase
 
         $this->exporter->createEvent('event', 'entity-type', 'entity-id', null, null, null, '2015-04-01');
 
-        $this->assertEquals(1, count($this->exporter->data));
+        $this->assertCount(1, $this->exporter->data);
         $data = $this->exporter->data[0];
-        $this->assertEquals(4, count($data));
+        $this->assertCount(4, $data);
         $this->assertEquals('event', $data['event']);
         $this->assertEquals('entity-type', $data['entityType']);
         $this->assertEquals('entity-id', $data['entityId']);
         $this->assertEquals($time->format(\DateTime::ISO8601), $data['eventTime'], 'time is string', 1);
 
-        $this->assertEquals(1, count($this->exporter->json));
+        $this->assertCount(1, $this->exporter->json);
         $json = $this->exporter->json[0];
         $pattern = '/^{"event":"event","entityType":"entity-type","entityId":"entity-id","eventTime":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{4}"}$/';
-        $this->assertTrue(preg_match($pattern, $json) === 1, 'json');
+        $this->assertRegExp($pattern, $json, 'json');
     }
 
     public function testTimeIsDateTime()
@@ -103,18 +104,18 @@ class ExporterTest extends \PHPUnit_Framework_TestCase
 
         $this->exporter->createEvent('event', 'entity-type', 'entity-id', null, null, null, $time);
 
-        $this->assertEquals(1, count($this->exporter->data));
+        $this->assertCount(1, $this->exporter->data);
         $data = $this->exporter->data[0];
-        $this->assertEquals(4, count($data));
+        $this->assertCount(4, $data);
         $this->assertEquals('event', $data['event']);
         $this->assertEquals('entity-type', $data['entityType']);
         $this->assertEquals('entity-id', $data['entityId']);
         $this->assertEquals($time->format(\DateTime::ISO8601), $data['eventTime'], 'time is DateTime', 1);
 
-        $this->assertEquals(1, count($this->exporter->json));
+        $this->assertCount(1, $this->exporter->json);
         $json = $this->exporter->json[0];
         $pattern = '/^{"event":"event","entityType":"entity-type","entityId":"entity-id","eventTime":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{4}"}$/';
-        $this->assertTrue(preg_match($pattern, $json) === 1, 'json');
+        $this->assertRegExp($pattern, $json, 'json');
     }
 
     public function testOptionalFields()
@@ -131,9 +132,9 @@ class ExporterTest extends \PHPUnit_Framework_TestCase
             $time
         );
 
-        $this->assertEquals(1, count($this->exporter->data));
+        $this->assertCount(1, $this->exporter->data);
         $data = $this->exporter->data[0];
-        $this->assertEquals(7, count($data));
+        $this->assertCount(7, $data);
         $this->assertEquals('event', $data['event']);
         $this->assertEquals('entity-type', $data['entityType']);
         $this->assertEquals('entity-id', $data['entityId']);
@@ -142,9 +143,9 @@ class ExporterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('target-entity-id', $data['targetEntityId']);
         $this->assertEquals(['property'=>true], $data['properties']);
 
-        $this->assertEquals(1, count($this->exporter->json));
+        $this->assertCount(1, $this->exporter->json);
         $json = $this->exporter->json[0];
         $pattern = '/^{"event":"event","entityType":"entity-type","entityId":"entity-id","eventTime":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{4}","targetEntityType":"target-entity-type","targetEntityId":"target-entity-id","properties":{"property":true}}$/';
-        $this->assertTrue(preg_match($pattern, $json) === 1, 'json');
+        $this->assertRegExp($pattern, $json, 'json');
     }
 }

--- a/tests/Unit/FileExporterTest.php
+++ b/tests/Unit/FileExporterTest.php
@@ -18,10 +18,11 @@
 namespace predictionio\tests\Unit;
 
 use predictionio\FileExporter;
+use PHPUnit\Framework\TestCase;
 
-class FileExporterTest extends \PHPUnit_Framework_TestCase
+class FileExporterTest extends TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         register_shutdown_function(function () {
             if (file_exists('temp.file')) {


### PR DESCRIPTION
# Changed log
- Defining `autoload-dev` block on `composer.json` to load test classes automatically.
- Using the `assertCount` and `assertRegExp` to assert expected array length is same as result and assert result is same as specific regular expression pattern.
- To support future stable `PHPUnit` version, using the `PHPUnit\Framework\TestCase` instead.
- Add `php-7.3` test on Travis CI build.